### PR TITLE
Support multiple ZooKeeper servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ with their default values, if any:
 - `ZOOKEEPER_PORT=2181`
 
   Used in constructing Kafka's `zookeeper.connect` setting.
+- `ZOOKEEPER_CONNECTION_STRING=<comma separated string of host:port pairs>`
+
+  Set a string with host:port pairs for connecting to a ZooKeeper Cluster. This
+  setting overrides ZOOKEEPER_IP and ZOOKEEPER_PORT.
 - `ZOOKEEPER_CHROOT`, ex: `/v0_8_1`
 
   ZooKeeper root path used in constructing Kafka's `zookeeper.connect` setting.

--- a/config/server.properties.template
+++ b/config/server.properties.template
@@ -62,7 +62,7 @@ log.retention.hours=168
 # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
 # You can also append an optional chroot string to the urls to specify the
 # root directory for all kafka znodes.
-zookeeper.connect={{ZOOKEEPER_IP}}:{{ZOOKEEPER_PORT}}{{ZOOKEEPER_CHROOT}}
+zookeeper.connect={{ZOOKEEPER_CONNECTION_STRING}}{{ZOOKEEPER_CHROOT}}
 zookeeper.connection.timeout.ms=10000
 controlled.shutdown.enable=true
 zookeeper.session.timeout.ms=10000

--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ IP=$(cat /etc/hosts | head -n1 | awk '{print $1}')
 # string with multiple ZooKeeper hosts
 [ -n "$ZOOKEEPER_CONNECTION_STRING" ] && ZOOKEEPER_CONNECTION_STRING"=${ZOOKEEPER_IP}:${ZOOKEEPER_PORT:-2181}"
 
-cat /kafka/config/server.properties${EXTENSION} | sed \
+cat /kafka/config/server.properties.template | sed \
   -e "s|{{ZOOKEEPER_CONNECTION_STRING}}|${ZOOKEEPER_CONNECTION_STRING}|g" \
   -e "s|{{ZOOKEEPER_CHROOT}}|${ZOOKEEPER_CHROOT:-}|g" \
   -e "s|{{KAFKA_BROKER_ID}}|${KAFKA_BROKER_ID:-0}|g" \

--- a/start.sh
+++ b/start.sh
@@ -7,9 +7,12 @@
 
 IP=$(cat /etc/hosts | head -n1 | awk '{print $1}')
 
-cat /kafka/config/server.properties.template | sed \
-  -e "s|{{ZOOKEEPER_IP}}|${ZOOKEEPER_IP}|g" \
-  -e "s|{{ZOOKEEPER_PORT}}|${ZOOKEEPER_PORT:-2181}|g" \
+# Concatenate the IP:PORT for ZooKeeper to allow setting a full connection
+# string with multiple ZooKeeper hosts
+[ -n "$ZOOKEEPER_CONNECTION_STRING" ] && ZOOKEEPER_CONNECTION_STRING"=${ZOOKEEPER_IP}:${ZOOKEEPER_PORT:-2181}"
+
+cat /kafka/config/server.properties${EXTENSION} | sed \
+  -e "s|{{ZOOKEEPER_CONNECTION_STRING}}|${ZOOKEEPER_CONNECTION_STRING}|g" \
   -e "s|{{ZOOKEEPER_CHROOT}}|${ZOOKEEPER_CHROOT:-}|g" \
   -e "s|{{KAFKA_BROKER_ID}}|${KAFKA_BROKER_ID:-0}|g" \
   -e "s|{{KAFKA_ADVERTISED_HOST_NAME}}|${KAFKA_ADVERTISED_HOST_NAME:-$IP}|g" \


### PR DESCRIPTION
In order to connect to a ZooKeeper cluster, one should/need to have several ZooKeeper hosts in the connection string. This is a comma separated host:port pairs, each corresponding to a zk server. 

For example: "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".

The PR is backwards compatible with the ZOOKEEPER_HOST + ZOOKEEPER_IP settings.