### PR TITLE
Remove the kafka user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,6 @@ RUN tar -zx -C /kafka --strip-components=1 -f ${KAFKA_RELEASE_ARCHIVE} && \
 ADD config /kafka/config
 ADD start.sh /start.sh
 
-# Set up a user to run Kafka
-RUN groupadd kafka && \
-  useradd -d /kafka -g kafka -s /bin/false kafka && \
-  chown -R kafka:kafka /kafka /data /logs
-USER kafka
 ENV PATH /kafka/bin:$PATH
 WORKDIR /kafka
 


### PR DESCRIPTION
As we don’t need to be a kafka user, let not be.
I know that be a root is never recommended, but does it stil make sense to do everything to not be a root in a docker?

Why stay as a root?
Be as another user is causing some issues around permissions. (https://github.com/ches/docker-kafka/issues/9)