### PR TITLE
Fixes `advertised.host.name` resolution in Docker 1.10.0

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -5,7 +5,7 @@
 [ -n "$ZOOKEEPER_PORT_2181_TCP_ADDR" ] && ZOOKEEPER_IP=$ZOOKEEPER_PORT_2181_TCP_ADDR
 [ -n "$ZOOKEEPER_PORT_2181_TCP_PORT" ] && ZOOKEEPER_PORT=$ZOOKEEPER_PORT_2181_TCP_PORT
 
-IP=$(cat /etc/hosts | head -n1 | awk '{print $1}')
+IP=$(grep ${HOSTNAME} /etc/hosts | awk '{print $1}')
 
 # Concatenate the IP:PORT for ZooKeeper to allow setting a full connection
 # string with multiple ZooKeeper hosts


### PR DESCRIPTION
`start.sh` should now correctly pick up the container's IP, no
matter where it shows up in `/etc/hosts`, instead of expecting
it to be in the first line

Resolves ches/docker-kafka#13