### PR TITLE
Update to java 8 and kafka 0.10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## latest - Unreleased
 
+## 0.10.0.0 - 1 June, 2016
+
+- Updated to Kafka 0.10.0.0
+- Updated to Java 8
+
 ## 0.9.0.1 - 17 April, 2016
 
 - Updated to Kafka 0.9.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@
 # major Java projects test and recommend Oracle Java for production for optimal
 # performance.
 
-FROM netflixoss/java:7
+FROM netflixoss/java:8
 MAINTAINER Ches Martin <ches@whiskeyandgrits.net>
 
-# The Scala 2.10 build is currently recommended by the project.
-ENV KAFKA_VERSION=0.9.0.1 KAFKA_SCALA_VERSION=2.11 JMX_PORT=7203
+# The Scala 2.11 build is currently recommended by the project.
+ENV KAFKA_VERSION=0.10.0.0 KAFKA_SCALA_VERSION=2.11 JMX_PORT=7203
 ENV KAFKA_RELEASE_ARCHIVE kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}.tgz
 
 RUN mkdir /kafka /data /logs


### PR DESCRIPTION
Resolves #15 by upgrading kafka to 0.10.0.0 and also updates to java 8 which is the [recommended java version](http://kafka.apache.org/documentation.html#java) for kafka 0.10.0.0