### PR TITLE
Create config backdoor

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ with their default values, if any:
   will create the path in ZK automatically; with earlier versions, you must
   ensure it is created before starting brokers.
 
+- `KAFKA_SERVER_CONFIG=<comma separated configuration.setting=value>`
+
+  Allows direct addition to the server.properties file for testing more complex 
+  options.
+
 JMX
 ---
 

--- a/start.sh
+++ b/start.sh
@@ -24,6 +24,8 @@ cat /kafka/config/server.properties.template | sed \
   -e "s|{{GROUP_MAX_SESSION_TIMEOUT_MS}}|${GROUP_MAX_SESSION_TIMEOUT_MS:-300000}|g" \
    > /kafka/config/server.properties
 
+echo $KAFKA_SERVER_CONFIG | tr ',' '\n' >> /kafka/config/server.properties
+
 # Kafka's built-in start scripts set the first three system properties here, but
 # we add two more to make remote JMX easier/possible to access in a Docker
 # environment:


### PR DESCRIPTION
This change allows the setting of any of the many server properties.

It's a little hacky, but very useful for exploring some of the more
interesting kafka configuration options.
