### PR TITLE
Kafka 0.10.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM netflixoss/java:8
 MAINTAINER Ches Martin <ches@whiskeyandgrits.net>
 
 # The Scala 2.11 build is currently recommended by the project.
-ENV KAFKA_VERSION=0.10.0.1 KAFKA_SCALA_VERSION=2.11 JMX_PORT=7203
+ENV KAFKA_VERSION=0.10.1.0 KAFKA_SCALA_VERSION=2.11 JMX_PORT=7203
 ENV KAFKA_RELEASE_ARCHIVE kafka_${KAFKA_SCALA_VERSION}-${KAFKA_VERSION}.tgz
 
 RUN mkdir /kafka /data /logs


### PR DESCRIPTION
The latest stable release: https://archive.apache.org/dist/kafka/0.10.1.0/RELEASE_NOTES.html