### PR TITLE
Add configuration parameter for Kafka's default replication factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ with their default values, if any:
   `advertised.port` setting. If you run multiple broker containers on a single
   Docker host and need them to be accessible externally, this should be set to
   the port that you forward to on the Docker host.
+- `KAFKA_DEFAULT_REPLICATION_FACTOR=1`
+
+  Maps to Kafka's `default.replication.factor` setting. The default replication
+  factor for automatically created topics.
 - `JAVA_RMI_SERVER_HOSTNAME=$KAFKA_ADVERTISED_HOST_NAME`
 
   Maps to the `java.rmi.server.hostname` JVM property, which is used to bind the

--- a/config/server.properties.template
+++ b/config/server.properties.template
@@ -22,7 +22,7 @@ auto.leader.rebalance.enable=true
 
 # Replication
 auto.create.topics.enable=true
-default.replication.factor=1
+default.replication.factor={{KAFKA_DEFAULT_REPLICATION_FACTOR}}
 
 # Hostname the broker will advertise to consumers. If not set, kafka will use the value returned
 # from InetAddress.getLocalHost().  If there are multiple interfaces getLocalHost

--- a/start.sh
+++ b/start.sh
@@ -22,6 +22,7 @@ cat /kafka/config/server.properties.template | sed \
   -e "s|{{ZOOKEEPER_CONNECTION_TIMEOUT_MS}}|${ZOOKEEPER_CONNECTION_TIMEOUT_MS:-10000}|g" \
   -e "s|{{ZOOKEEPER_SESSION_TIMEOUT_MS}}|${ZOOKEEPER_SESSION_TIMEOUT_MS:-10000}|g" \
   -e "s|{{GROUP_MAX_SESSION_TIMEOUT_MS}}|${GROUP_MAX_SESSION_TIMEOUT_MS:-300000}|g" \
+  -e "s|{{KAFKA_DEFAULT_REPLICATION_FACTOR}}|${KAFKA_DEFAULT_REPLICATION_FACTOR:-1}|g" \
    > /kafka/config/server.properties
 
 # Kafka's built-in start scripts set the first three system properties here, but


### PR DESCRIPTION
Configures Kafka's default replication factor for automatically created topics. Default value if unset will be 1, as before.