### PR TITLE
Add a configuration option for message.max.bytes and replica.fetch.max.bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ with their default values, if any:
 
   Maps to Kafka's `log.retention.hours`. The number of hours to keep a log file
   before deleting it.
+
+- `KAFKA_MESSAGE_MAX_BYTES`
+
+  Maps to Kafka's `message.max.bytes`. The maximum size of message that the
+  server can receive. Default: 1000012
+
+- `KAFKA_REPLICA_FETCH_MAX_BYTES`
+
+  Maps to Kafka's `replica.fetch.max.bytes`. The number of bytes of messages to 
+  attempt to fetch for each partition. This is not an absolute maximum, if 
+  the first message in the first non-empty partition of the fetch is larger 
+  than this value, the message will still be returned to ensure that progress 
+  can be made. The maximum message size accepted by the broker is defined via 
+  message.max.bytes (broker config) or max.message.bytes (topic config). 
+  Default: 1048576
+
 - `JAVA_RMI_SERVER_HOSTNAME=$KAFKA_ADVERTISED_HOST_NAME`
 
   Maps to the `java.rmi.server.hostname` JVM property, which is used to bind the

--- a/config/server.properties.template
+++ b/config/server.properties.template
@@ -74,5 +74,7 @@ controlled.shutdown.enable=true
 group.max.session.timeout.ms={{KAFKA_GROUP_MAX_SESSION_TIMEOUT_MS}}
 inter.broker.protocol.version={{KAFKA_INTER_BROKER_PROTOCOL_VERSION}}
 log.message.format.version={{KAFKA_LOG_MESSAGE_FORMAT_VERSION}}
+message.max.bytes={{KAFKA_MESSAGE_MAX_BYTES}}
+replica.fetch.max.bytes={{KAFKA_REPLICA_FETCH_MAX_BYTES}}
 
 # vim:set filetype=jproperties

--- a/start.sh
+++ b/start.sh
@@ -28,6 +28,8 @@ cat /kafka/config/server.properties.template | sed \
   -e "s|{{ZOOKEEPER_CONNECTION_STRING}}|${ZOOKEEPER_CONNECTION_STRING}|g" \
   -e "s|{{ZOOKEEPER_CONNECTION_TIMEOUT_MS}}|${ZOOKEEPER_CONNECTION_TIMEOUT_MS:-10000}|g" \
   -e "s|{{ZOOKEEPER_SESSION_TIMEOUT_MS}}|${ZOOKEEPER_SESSION_TIMEOUT_MS:-10000}|g" \
+  -e "s|{{KAFKA_MESSAGE_MAX_BYTES}}|${KAFKA_MESSAGE_MAX_BYTES:-1000012}|g" \
+  -e "s|{{KAFKA_REPLICA_FETCH_MAX_BYTES}}|${KAFKA_REPLICA_FETCH_MAX_BYTES:-1048576}|g" \
    > /kafka/config/server.properties
 
 # Kafka's built-in start scripts set the first three system properties here, but


### PR DESCRIPTION
Hi,

First let me start by saying thank you for taking the time to create and maintain this Docker image for Kafka. We are currently moving forward with using this image in particular and it would be helpful to be able to configure the max message size that the broker accepts.

The following PR does the changes to the repo to achieve this. I have tested this internally and it works for us.

If you have a bit of time to review it, maybe we can merge them in.

Regards,
