### PR TITLE
Add option for disabling unclean leader election

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ with their default values, if any:
   will create the path in ZK automatically; with earlier versions, you must
   ensure it is created before starting brokers.
 
+- `KAFKA_UNCLEAN_LEADER_ELECTION=(true|false)`, Default here: `false`
+  Favour availability over consistency by allowing a non-ISR replica to become
+  a leader for a partition, possibly losing writes. Disabled by default from
+  version `0.11.0.0`
+
 JMX
 ---
 

--- a/config/server.properties.template
+++ b/config/server.properties.template
@@ -76,5 +76,6 @@ inter.broker.protocol.version={{KAFKA_INTER_BROKER_PROTOCOL_VERSION}}
 log.message.format.version={{KAFKA_LOG_MESSAGE_FORMAT_VERSION}}
 message.max.bytes={{KAFKA_MESSAGE_MAX_BYTES}}
 replica.fetch.max.bytes={{KAFKA_REPLICA_FETCH_MAX_BYTES}}
+unclean.leader.election.enable={{KAFKA_UNCLEAN_LEADER_ELECTION}}
 
 # vim:set filetype=jproperties

--- a/start.sh
+++ b/start.sh
@@ -30,6 +30,7 @@ cat /kafka/config/server.properties.template | sed \
   -e "s|{{ZOOKEEPER_SESSION_TIMEOUT_MS}}|${ZOOKEEPER_SESSION_TIMEOUT_MS:-10000}|g" \
   -e "s|{{KAFKA_MESSAGE_MAX_BYTES}}|${KAFKA_MESSAGE_MAX_BYTES:-1000012}|g" \
   -e "s|{{KAFKA_REPLICA_FETCH_MAX_BYTES}}|${KAFKA_REPLICA_FETCH_MAX_BYTES:-1048576}|g" \
+  -e "s|{{KAFKA_UNCLEAN_LEADER_ELECTION}}|${KAFKA_UNCLEAN_LEADER_ELECTION:-false}|g" \
    > /kafka/config/server.properties
 
 # Kafka's built-in start scripts set the first three system properties here, but


### PR DESCRIPTION
Its disabled by default here, in effort to be idiomatic, as it will be
disabled in newer versions of kafka by default too. (from `0.11.0.0`)

Let me know what you think, and if you need help backporting it to older tags (I'm interested in the v0.10.0.1 tag myself)

Btw, this is a fantastic repository. A while ago I tried to achieve a similar thing: getting kafka to run on a single docker host. You've kept this updated, and in pristine condition. :+1: good work!